### PR TITLE
Make drupal-vm dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To use this plugin, you must already have a Drupal project using BLT 12 or highe
 
 In your project, require the plugin with Composer:
 
-`composer require acquia/blt-drupal-vm`
+`composer require acquia/blt-drupal-vm --dev`
 
 # License
 


### PR DESCRIPTION
Drupal vm is a local development requirement, hence it should added as dev dependency.